### PR TITLE
Add light and mark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
     <link rel="stylesheet" href="whack-a-mole.css">
 </head>
 <body>
+    <!-- LIGHT AND DARK MODE -->
+     <button id="theme-toggle" class="theme-toggle-btn">
+     <i class="fas fa-moon"></i> Toggle Dark Mode
+     </button>
+
     <div class="game-container">
         <h1>Whack-a-Mole</h1>
         

--- a/whack-a-mole.css
+++ b/whack-a-mole.css
@@ -243,11 +243,14 @@ h1 {
 }
 
 /* LIGHT AND DARK MODE */
+
 body.dark-mode {
-  --bg-color: #212121;
-  --text-color: #f6f6f6;
   background-color: #212121 !important;
-  background-image: none !important;
+  background-image:
+  linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
+  url("https://i.pinimg.com/1200x/b5/37/f6/b537f6af75a3573bda5c9148ed16c5dc.jpg") !important;
+  background-size: cover;
+  background-position: center;
   color: var(--text-color);
 }
 

--- a/whack-a-mole.css
+++ b/whack-a-mole.css
@@ -241,3 +241,55 @@ h1 {
   animation: shake 0.3s ease-in-out;
   animation-fill-mode: forwards;
 }
+
+/* LIGHT AND DARK MODE */
+body.dark-mode {
+  --bg-color: #212121;
+  --text-color: #f6f6f6;
+  background-color: #212121 !important;
+  background-image: none !important;
+  color: var(--text-color);
+}
+
+body.dark-mode .game-container {
+  background-color: #2d2d2d;
+  color: #f6f6f6;
+  box-shadow: 0 0 20px rgba(30,30,60,0.5);
+}
+
+body.dark-mode h1 {
+  color: #ffee58;
+  text-shadow: 0 0 8px #283593;
+}
+body.dark-mode .game-info,
+body.dark-mode .score-popup,
+body.dark-mode .game-over-tag,
+body.dark-mode .footer {
+  background-color: #26283f;
+  color: #ffe082;
+}
+
+body.dark-mode .hole {
+  background-color: #463018;
+  box-shadow: inset 0 10px 0 5px rgba(255,255,255, 0.08);
+}
+
+.theme-toggle-btn {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 30;
+  padding: 8px 14px;
+  background: #222;
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 1.05rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+  transition: all .2s;
+}
+.theme-toggle-btn:hover {
+  background: #434343;
+  color: #ffee58;
+}

--- a/whack-a-mole.js
+++ b/whack-a-mole.js
@@ -221,3 +221,22 @@ moles.forEach(mole => {
         }
     });
 });
+
+// LIGHT AND DARK MODE
+const themeToggleBtn = document.getElementById('theme-toggle');
+
+if (localStorage.getItem('theme') === 'dark') {
+  document.body.classList.add('dark-mode');
+  themeToggleBtn.innerHTML = '<i class="fas fa-sun"></i> Toggle Light Mode';
+}
+
+themeToggleBtn.addEventListener('click', () => {
+  document.body.classList.toggle('dark-mode');
+  const isDark = document.body.classList.contains('dark-mode');
+  themeToggleBtn.innerHTML = isDark
+    ? '<i class="fas fa-sun"></i> Toggle Light Mode'
+    : '<i class="fas fa-moon"></i> Toggle Dark Mode';
+
+  //  choice
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+});


### PR DESCRIPTION
Description :
- Added a button to allow users to switch between light and dark mode.
- Implemented CSS for dark mode and ensured all UI elements adapt accordingly.
- Used localStorage to remember the preferred theme across sessions.

Issue #14 

Screenshot : 
light mode =
<img width="1440" height="932" alt="Screenshot 2025-08-01 at 2 57 47 PM" src="https://github.com/user-attachments/assets/5a8c1af9-62b6-4a27-a583-fd7a3eee4e1b" />

Dark mode = 
<img width="1440" height="932" alt="Screenshot 2025-08-01 at 2 57 52 PM" src="https://github.com/user-attachments/assets/14e1521a-f1a9-4dc9-a08e-19d918225bc4" />

Thankyou.